### PR TITLE
chore(github-actions): add typos on pr workflow

### DIFF
--- a/.github/workflows/tldr-pr.yml
+++ b/.github/workflows/tldr-pr.yml
@@ -1,0 +1,15 @@
+name: typos on PR
+on: [pull_request]
+
+jobs:
+  run:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v4
+
+      - name: Check spelling on Markdown files
+        uses: crate-ci/typos@master
+        with:
+          files: ./*.md


### PR DESCRIPTION
This pull request adds `typos` command for markdown files on PR workflow GitHub actions.

Issue #8 