### PR TITLE
fix: run spell check on all files

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -12,5 +12,3 @@ jobs:
 
       - name: Run Spell Check on Markdown Files
         uses: crate-ci/typos@master
-        with:
-          files: ./*.md


### PR DESCRIPTION
The spell check workflow doesn't seem to run on markdown files. so changed it to run on all files.