### PR TITLE
chore(github-actions): change trigger in greetings workflow

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [pull_request_target, issues]
+on: [pull_request, issues]
 
 jobs:
   greeting:


### PR DESCRIPTION
This pull request changes `pull_request_target` trigger to `pull_request` in the greetings workflow due to security concerns. I request the repository maintainers to review and merge it.

Thanks! :heart: